### PR TITLE
Auto Detrend for non-XDF formats, and display corrected values in Y axis widget

### DIFF
--- a/src/file_handling/basic_header.cpp
+++ b/src/file_handling/basic_header.cpp
@@ -26,20 +26,30 @@ uint32 BasicHeader::getNumberEvents() const
     return number_events_;
 }
 
+//-------------------------------------------------------------------------
 void BasicHeader::setNumberEvents(uint32 number_events)
 {
     number_events_ = number_events;
 }
 
-// get event samplerate
+//get event samplerate-----------------------------------------------------
 double BasicHeader::getEventSamplerate() const
 {
     return sample_rate_;
 }
 
+//-------------------------------------------------------------------------
 void BasicHeader::setEventSamplerate(double event_sample_rate)
 {
     event_sample_rate_ = event_sample_rate;
+}
+//-------------------------------------------------------------------------
+float64 BasicHeader::getMean(ChannelID id) const
+{
+    if (means_.size() > id)
+        return means_[id];
+    else
+        return 0;
 }
 
 //-------------------------------------------------------------------------

--- a/src/file_handling/basic_header.h
+++ b/src/file_handling/basic_header.h
@@ -62,6 +62,11 @@ public:
     double getEventSamplerate() const;
     void setEventSamplerate (double event_sample_rate);
 
+    //-------------------------------------------------------------------------
+    float64 getMean (ChannelID id) const;
+
+    //-------------------------------------------------------------------------
+    QVector<float64> means_;
 
 protected:
     //-------------------------------------------------------------------------

--- a/src/file_handling/channel_manager.cpp
+++ b/src/file_handling/channel_manager.cpp
@@ -109,8 +109,8 @@ void ChannelManager::initMinMax () const
     foreach (ChannelID id, getChannels())
     {
         QSharedPointer<DataBlock const> data = getData (id, 0, getNumberSamples ());
-        max_values_[id] = data->getMax ();
-        min_values_[id] = data->getMin ();
+        max_values_[id] = data->getMax () + getMean(id);
+        min_values_[id] = data->getMin () + getMean(id);
         ProgressBar::instance().increaseValue (1, QObject::tr("Searching for Min-Max"));
     }
     min_max_initialized_ = true;

--- a/src/file_handling/channel_manager.h
+++ b/src/file_handling/channel_manager.h
@@ -57,6 +57,9 @@ public:
     virtual float64 getSampleRate () const = 0;
 
     //-------------------------------------------------------------------------
+    virtual float64 getMean (ChannelID id) const {return 0;}/*!< This function is only available at channel_manager_impl.cpp. */
+
+    //-------------------------------------------------------------------------
     void addDownsampledMinMaxVersion (ChannelID id, QSharedPointer<DataBlock const> min,
                                       QSharedPointer<DataBlock const> max, unsigned factor);
 

--- a/src/file_handling_impl/biosig_reader.cpp
+++ b/src/file_handling_impl/biosig_reader.cpp
@@ -199,6 +199,12 @@ void BioSigReader::bufferAllChannels () const
         for (size_t data_index = 0; data_index < numberOfSamples; data_index++)
             raw_data->operator [](data_index) = read_data[data_index + channel_id * numberOfSamples];
 
+        //Calculate mean
+        float64 init = 0.0;
+        float64 mean = std::accumulate(raw_data->begin(), raw_data->end(), init) / raw_data->size();
+        std::transform(raw_data->begin(), raw_data->end(), raw_data->begin(), bind2nd(std::minus<double>(), mean));
+        basic_header_->means_.push_back(mean);
+
         QSharedPointer<DataBlock const> data_block(new FixedDataBlock(raw_data, basic_header_->getSampleRate()));
         channel_map_[channel_id] = data_block;
     }

--- a/src/file_handling_impl/channel_manager_impl.cpp
+++ b/src/file_handling_impl/channel_manager_impl.cpp
@@ -90,4 +90,10 @@ float64 ChannelManagerImpl::getSampleRate () const
     return reader_->getBasicHeader()->getSampleRate();
 }
 
+//-------------------------------------------------------------------------
+float64 ChannelManagerImpl::getMean(ChannelID id) const
+{
+    return reader_->getBasicHeader()->getMean(id);
+}
+
 }

--- a/src/file_handling_impl/channel_manager_impl.h
+++ b/src/file_handling_impl/channel_manager_impl.h
@@ -54,6 +54,9 @@ public:
     //-------------------------------------------------------------------------
     virtual float64 getSampleRate() const;
 
+    //-------------------------------------------------------------------------
+    virtual float64 getMean(ChannelID id) const;
+
 private:
     FileSignalReader* reader_;
 };

--- a/src/gui_impl/signal_browser/signal_graphics_item.cpp
+++ b/src/gui_impl/signal_browser/signal_graphics_item.cpp
@@ -50,6 +50,7 @@ SignalGraphicsItem::SignalGraphicsItem (QSharedPointer<SignalViewSettings const>
   signal_browser_model_(model),
   minimum_ (channel_manager_.getMinValue (id_)),
   maximum_ (channel_manager_.getMaxValue (id_)),
+  mean_ (channel_manager_.getMean(id_)),
   y_zoom_ (1),
   draw_y_grid_ (true),
   draw_x_grid_ (true),

--- a/src/gui_impl/signal_browser/signal_graphics_item.h
+++ b/src/gui_impl/signal_browser/signal_graphics_item.h
@@ -51,6 +51,7 @@ public:
     float64 getYGridPixelIntervall() const;
     double getValueRangeFragment () const;
     QString getPhysicalDimensionString () const;
+    float64 getMean() const {return mean_;}
 
     void zoomIn();
     void zoomOut();
@@ -92,6 +93,7 @@ private:
 
     float64 minimum_;
     float64 maximum_;
+    float64 mean_;
 
     float64 y_zoom_;
     float64 y_grid_pixel_intervall_;

--- a/src/gui_impl/signal_browser/y_axis_widget_4.cpp
+++ b/src/gui_impl/signal_browser/y_axis_widget_4.cpp
@@ -81,7 +81,7 @@ void YAxisWidget::paintEvent(QPaintEvent*)
             current_y_start <= y_start_ + height ())
             paintYAxisLabels (&painter, signal->getYOffset(),signal->getYGridPixelIntervall(),
                               signal->getValueRangeFragment(),
-                              signal->getPhysicalDimensionString());
+                              signal->getPhysicalDimensionString(), signal->getMean());
         painter.translate (0, intervall);
         current_y_start += intervall;
     }
@@ -105,7 +105,7 @@ void YAxisWidget::contextMenuEvent (QContextMenuEvent* event)
 void YAxisWidget::paintYAxisLabels (QPainter* painter, float64 offset,
                                     float64 y_grid_pixel_intervall,
                                     double value_range_fragment,
-                                    QString const& unit_string)
+                                    QString const& unit_string, float64 mean)
 {
     int upper_border = channel_height_ / 2;
     int lower_border = -static_cast<int>(channel_height_ / 2);
@@ -119,9 +119,10 @@ void YAxisWidget::paintYAxisLabels (QPainter* painter, float64 offset,
 
     paintYUnits (painter, unit_string);
 
-    painter->drawText (0, offset - 20, width () - 10, 40,
-                       Qt::AlignRight | Qt::AlignVCenter,
-                       QString::number (0));
+    //! The step below is duplicate
+//    painter->drawText (0, offset - 20, width () - 10, 40,
+//                       Qt::AlignRight | Qt::AlignVCenter,
+//                       QString::number (0));
     if (y_grid_pixel_intervall < 1)
         return;
 
@@ -142,7 +143,7 @@ void YAxisWidget::paintYAxisLabels (QPainter* painter, float64 offset,
             painter->drawLine (width () - 5, value_y, width () - 1, value_y);
             painter->drawText(0, value_y - 20, width () - 10, 40,
                              Qt::AlignRight | Qt::AlignVCenter,
-                             QString::number (value));
+                             QString::number (value + mean, 'f', 0));
         }
         value -= value_range_fragment;
     }
@@ -158,7 +159,7 @@ void YAxisWidget::paintYAxisLabels (QPainter* painter, float64 offset,
             painter->drawLine (width () - 5, value_y, width () - 1, value_y);
             painter->drawText(0, value_y - 20, width () - 10, 40,
                              Qt::AlignRight | Qt::AlignVCenter,
-                             QString::number (value));
+                             QString::number (value + mean, 'f', 0));
         }
     }
 }

--- a/src/gui_impl/signal_browser/y_axis_widget_4.h
+++ b/src/gui_impl/signal_browser/y_axis_widget_4.h
@@ -39,7 +39,7 @@ private:
     void paintYAxisLabels (QPainter* painter, float64 offset,
                            float64 y_grid_pixel_intervall,
                            double value_range_fragment,
-                           QString const& unit_string);
+                           QString const& unit_string, float64 mean = 0);
 
     void paintYUnits (QPainter* painter, QString const& unit_string);
 


### PR DESCRIPTION
Auto Detrend for non-XDF formats, and display corrected values in Y Axis widget.

Problem: In non-XDF files, min and max values are never correctly displayed in the info dialog.

I suggest we merge the XDF branch soon because I sense there might be some potential conflicts we need to solve, and it would be less confusing if we want to add more new features