### PR TITLE
Change 1/100 to 1/20

### DIFF
--- a/src/file_handling_impl/xdf_reader.cpp
+++ b/src/file_handling_impl/xdf_reader.cpp
@@ -194,7 +194,7 @@ QString XDFReader::loadFixedHeader(const QString& file_path)
             for (auto const stream : XDFdata->streams)
             {
                 if (std::abs(stream.info.effective_sample_rate - stream.info.nominal_srate) >
-                        stream.info.nominal_srate / 100)
+                        stream.info.nominal_srate / 20)
                 {
                     showWarning = true;
                 }


### PR DESCRIPTION
1/100 is too much. Basically I see warnings on every file that I have. 1/20 is better.

But then, since most of files are not that accurate in term of sample rate, shall we still persist in using nominal rate, or considering some other approaches (either effective rate, or using time stamp)?