### PR TITLE
Effective sample rate events

### DIFF
--- a/src/file_handling_impl/xdf_reader.cpp
+++ b/src/file_handling_impl/xdf_reader.cpp
@@ -151,6 +151,19 @@ QString XDFReader::loadFixedHeader(const QString& file_path)
                 XDFdata->calcTotalLength(XDFdata->majSR);
 
                 XDFdata->adjustTotalLength();
+
+                if (XDFdata->effectiveSampleRateVector.size())
+                {
+                    /* If and only if the file contains only one sample rate, we use effective
+                    sample rate to more accurately display events. Effective sample rates
+                    can be slightly different across streams, so we calculate the mean here */
+
+                    double init = 0.0;
+                    XDFdata->fileEffectiveSampleRate =
+                            std::accumulate(XDFdata->effectiveSampleRateVector.begin(),
+                                            XDFdata->effectiveSampleRateVector.end(), init)
+                            / XDFdata->effectiveSampleRateVector.size();
+                }
             }
                 break;
             case Multi_Sample_Rate:


### PR DESCRIPTION
If and only if the file contains only one sample rate, we use effective
sample rate to more accurately display events. 

This commit should be used in conjunction with the newest commit in libxdf.

A testing file can be found [here](https://www.dropbox.com/s/b7631y1qjnaxy56/454Hz_testing_file.xdf?dl=0): it has a nominal sample rate of 488Hz but an actuall sample rate of 454 Hz. If displayed correctly, the "TMS Hitting" events should align with the spikes in the 2nd channel of "RT-06-SpecFlt" stream.

Here is a [visualization script](https://www.dropbox.com/s/zoookxvaew6n98o/Visualization_script_for_Clemens.m?dl=0) in MatLab just for comparison

Ideally it should look like:
![image](https://user-images.githubusercontent.com/20526646/27468186-5c4a8f00-57b6-11e7-9f3a-0d4043a12950.png)

Wrong if:
![image](https://user-images.githubusercontent.com/20526646/27468261-d03893ee-57b6-11e7-939d-ab2c6ab6160c.png)
