### PR TITLE
Resize all dialogs relative to user's screen size

### DIFF
--- a/src/gui_impl/commands/help_gui_command.cpp
+++ b/src/gui_impl/commands/help_gui_command.cpp
@@ -8,7 +8,7 @@
 #include "ui_about_dialog.h"
 
 #include <QMessageBox>
-
+#include <QDesktopWidget>
 
 namespace sigviewer
 {
@@ -48,7 +48,12 @@ void HelpGuiCommand::showAboutDialog ()
     ui.aboutLabel->setText(ui.aboutLabel->text().replace(QString("VERSION_MAJOR"), QString::number(VERSION_MAJOR))
                                                 .replace(QString("VERSION_MINOR"), QString::number(VERSION_MINOR))
                                                 .replace(QString("VERSION_BUILD"), QString::number(VERSION_BUILD)));
-    dialog_->setFixedSize(dialog_->minimumSizeHint());
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.2;
+    int y=dw.height()*0.2;
+    dialog_->setFixedSize(x,y);
+
     dialog_->show();
 }
 

--- a/src/gui_impl/dialogs/basic_header_info_dialog.cpp
+++ b/src/gui_impl/dialogs/basic_header_info_dialog.cpp
@@ -17,6 +17,7 @@
 #include <QSettings>
 #include <QFileInfo>
 #include <QtXml>
+#include <QDesktopWidget>
 
 namespace sigviewer
 {
@@ -42,8 +43,14 @@ BasicHeaderInfoDialog::BasicHeaderInfoDialog(QSharedPointer<BasicHeader> header,
     button_layout->addWidget(toggle_button_);
     button_layout->addWidget(close_button_);
     button_layout->addStretch(1);
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.45;
+    int y=dw.height()*0.8;
+    setFixedSize(x,y);
+
     buildTree();
-    resize(850, 850);
+
     top_layout->activate();
     readSettings();
     connect(close_button_, SIGNAL(clicked()), this, SLOT(closeInfoDialog()));
@@ -121,7 +128,7 @@ void BasicHeaderInfoDialog::buildTree()
     info_tree_widget_->setHeaderLabels(header_labels);
 
     info_tree_widget_->header()->setSectionResizeMode(QHeaderView::Interactive);
-    info_tree_widget_->setColumnWidth(0, width() * 0.65);
+    info_tree_widget_->setColumnWidth(0, width() * 0.5);
     info_tree_widget_->setAnimated(true);
 
     QTreeWidgetItem* root_item;

--- a/src/gui_impl/dialogs/channel_selection_dialog.cpp
+++ b/src/gui_impl/dialogs/channel_selection_dialog.cpp
@@ -8,7 +8,7 @@
 #include "application_context_impl.h"
 
 #include <QColorDialog>
-
+#include <QDesktopWidget>
 
 namespace sigviewer
 {
@@ -34,7 +34,13 @@ ChannelSelectionDialog::ChannelSelectionDialog(ChannelManager const& channel_man
     headerLabels << tr("Channel") << tr("Color");
     ui_.treeWidget->setHeaderLabels(headerLabels);
     ui_.treeWidget->setColumnCount(2);
-    ui_.treeWidget->header()->resizeSection(0, width() * 0.6);
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.35;
+    int y=dw.height()*0.7;
+    setFixedSize(x,y);
+
+    ui_.treeWidget->header()->resizeSection(0, width() * 0.4);
     ui_.treeWidget->setAnimated(true);
 
     if (ApplicationContextImpl::getInstance()->getCurrentFileContext()->getFileName().endsWith("XDF", Qt::CaseInsensitive))

--- a/src/gui_impl/dialogs/event_time_selection_dialog.cpp
+++ b/src/gui_impl/dialogs/event_time_selection_dialog.cpp
@@ -7,6 +7,7 @@
 #include "file_handling/event_manager.h"
 
 #include <QPushButton>
+#include <QDesktopWidget>
 #include <limits>
 
 namespace sigviewer
@@ -23,6 +24,11 @@ EventTimeSelectionDialog::EventTimeSelectionDialog (std::set<EventType> const& s
       start_before_value_ (0)
 {
     ui_.setupUi (this);
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.3;
+    int y=dw.height()*0.6;
+    setFixedSize(x,y);
 
     foreach (ChannelID channel_id, shown_channels)
     {

--- a/src/gui_impl/dialogs/event_types_selection_dialog.cpp
+++ b/src/gui_impl/dialogs/event_types_selection_dialog.cpp
@@ -7,6 +7,7 @@
 
 #include <QColorDialog>
 #include <QInputDialog>
+#include <QDesktopWidget>
 
 #define max(a,b) ((a) > (b) ? (a) : (b))
 
@@ -38,6 +39,11 @@ void EventTypesSelectionDialog::buildTree (bool only_existing_events)
     header_labels << tr("Event Type") << tr("Color") << tr("Alpha") << tr("Type Id");
     ui_.tree_widget_->setHeaderLabels (header_labels);
     ui_.tree_widget_->setColumnWidth(ID_COLUMN_INDEX_, 0);
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.35;
+    int y=dw.height()*0.7;
+    setFixedSize(x,y);
 
     ui_.tree_widget_->header()->setSectionResizeMode (QHeaderView::Interactive);
     ui_.tree_widget_->header()->resizeSection (NAME_COLUMN_INDEX_, width() * 0.6);

--- a/src/gui_impl/dialogs/resampling_dialog.cpp
+++ b/src/gui_impl/dialogs/resampling_dialog.cpp
@@ -7,6 +7,8 @@
 #include "ui_resampling_dialog.h"
 #include "file_handling_impl/xdf_reader.h"
 
+#include <QDesktopWidget>
+
 namespace sigviewer {
 
 ResamplingDialog::ResamplingDialog(QWidget *parent) :
@@ -22,6 +24,12 @@ ResamplingDialog::ResamplingDialog(int nativeSrate, int highestSampleRate, QWidg
 {
     ui->setupUi(this);
     this->setWindowTitle("Resampling");
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.35;
+    int y=dw.height()*0.6;
+    setFixedSize(x,y);
+
 
     if (XDFdata->sampleRateMap.size() > 1)
     {
@@ -42,7 +50,7 @@ ResamplingDialog::ResamplingDialog(int nativeSrate, int highestSampleRate, QWidg
         ui->label->setText(text);
     }
     ui->treeWidget->setColumnCount(2);
-    ui->treeWidget->setColumnWidth(0, this->width()/2.15);
+    ui->treeWidget->setColumnWidth(0, this->width() * 0.48);
     ui->treeWidget->setAnimated(true);
     QStringList headers;
     headers << "Stream" << "Info";

--- a/src/gui_impl/dialogs/scale_channel_dialog.cpp
+++ b/src/gui_impl/dialogs/scale_channel_dialog.cpp
@@ -7,6 +7,7 @@
 
 #include <QDebug>
 #include <QSettings>
+#include <QDesktopWidget>
 
 #include <limits>
 
@@ -24,6 +25,11 @@ ScaleChannelDialog::ScaleChannelDialog (ChannelID preselected_channel,
     channel_manager_ (channel_manager)
 {
     ui_.setupUi (this);
+
+    QDesktopWidget dw;
+    int x=dw.width()*0.22;
+    int y=dw.height()*0.22;
+    setFixedSize(x,y);
 
     if (selected_channel_ == UNDEFINED_CHANNEL)
         setWindowTitle (tr("Scale All Channels"));


### PR DESCRIPTION
So that even if somebody uses SigViewer on a 4K screen, all dialogs still display in proper sizes relative to the screen resoluation