### PR TITLE
Fixed SEGV when saving to CSV after deleting an event

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version X.X.X
+(B) Fix crash when exporting events to CSV
+
 Version 0.6.4
 (+) Re-enable import/export event from/to EVT
 

--- a/src/gui_impl/commands/save_gui_command.cpp
+++ b/src/gui_impl/commands/save_gui_command.cpp
@@ -299,14 +299,17 @@ void SaveGuiCommand::exportEventsToCSV ()
 
         for (unsigned int i = 0; i < event_manager_pt->getNumberOfEvents(); i++)
         {
-            row tmp = {
-                event_manager_pt->getEvent(i)->getPosition(),
-                event_manager_pt->getEvent(i)->getDuration(),
-                event_manager_pt->getEvent(i)->getChannel(),
-                event_manager_pt->getEvent(i)->getType(),
-                event_manager_pt->getNameOfEvent(i)
-            };
-            events.append(tmp);
+            auto evt = event_manager_pt->getEvent();
+            if (evt != NULL) {
+                row tmp = {
+                    evt->getPosition(),
+                    evt->getDuration(),
+                    evt->getChannel(),
+                    evt->getType(),
+                    event_manager_pt->getNameOfEvent(i)
+                };
+                events.append(tmp);
+            }
         }
 
         std::sort(events.begin(),

--- a/src/gui_impl/commands/save_gui_command.cpp
+++ b/src/gui_impl/commands/save_gui_command.cpp
@@ -299,7 +299,7 @@ void SaveGuiCommand::exportEventsToCSV ()
 
         for (unsigned int i = 0; i < event_manager_pt->getNumberOfEvents(); i++)
         {
-            auto evt = event_manager_pt->getEvent();
+            auto evt = event_manager_pt->getEvent(i);
             if (evt != NULL) {
                 row tmp = {
                     evt->getPosition(),
@@ -350,7 +350,7 @@ void SaveGuiCommand::evaluateEnabledness ()
         no_gdf_file_open = !(applicationContext()->getCurrentFileContext()->getFileName().endsWith("gdf"));
         file_changed = (getFileState () == FILE_STATE_CHANGED);
         has_events = applicationContext()->getCurrentFileContext()->getEventManager()->getNumberOfEvents() > 0;
-      
+
         if (applicationContext()->getCurrentFileContext()->getFileName().endsWith("xdf"))
             no_gdf_file_open = false;//Disabled because currently XDF to GDF conversion doesn't work
     }


### PR DESCRIPTION
In the base implementation edited events are set to NULL when deleted.   This caused a SIGSEGV when the events are saved to CSV, for which this is a trivial patch.