### PR TITLE
Skip notarization for PRs from forks

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -68,6 +68,7 @@ jobs:
           echo "APP_VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Import Developer ID certificate
+        if: github.actor != 'dependabot[bot]'
         env:
           MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
           MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
@@ -83,9 +84,11 @@ jobs:
         run: $(brew --prefix qt)/bin/macdeployqt build/SigViewer.app
 
       - name: Sign .app bundle
+        if: github.actor != 'dependabot[bot]'
         run: 'codesign --deep --force --options runtime --sign "Developer ID Application: CLEMENS BRUNNER (9UC2D22DW3)" build/SigViewer.app'
 
       - name: Notarize .app bundle
+        if: github.actor != 'dependabot[bot]'
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
@@ -98,6 +101,7 @@ jobs:
             --wait
 
       - name: Staple .app bundle
+        if: github.actor != 'dependabot[bot]'
         run: xcrun stapler staple build/SigViewer.app
 
       - name: Create DMG

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
   workflow_call:
 
 jobs:


### PR DESCRIPTION
PRs from forks do not have access to the secrets, so the app cannot be signed and notarized. This PR disables this for Dependabot, but we'll have to think about a better solution, as this issue will apply to every PR from a fork.