### PR TITLE
Fix crash when loading multichannel string streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [UNRELEASED] · YYYY-MM-DD
+### 🔧 Fixed
+- Fix multi-channel string/marker stream parsing ([#164](https://github.com/cbrnr/sigviewer/pull/164) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix crash when loading XDF files containing a stream with only one sample ([#164](https://github.com/cbrnr/sigviewer/pull/164) by [Clemens Brunner](https://github.com/cbrnr))
+
 ## [0.7.1] · 2026-04-06
 ### ✨ Added
 - Add DMG background and Applications shortcut for macOS installer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(sigviewer
-    VERSION 0.7.1
+    VERSION 0.7.2
     LANGUAGES CXX C
 )
 
 # -- Pinned versions of external dependencies --------------------------------
 # These are the ONLY accepted versions. Change them here (and rebuild the
 # pre-built artifacts) when upgrading a dependency.
-set(LIBXDF_VERSION    "0.99.10")
-set(LIBBIOSIG_VERSION "3.9.4")
+set(LIBXDF_VERSION    "1.0.0")
+set(LIBBIOSIG_VERSION "3.9.5")
 
 # -- Language standards ------------------------------------------------------
 set(CMAKE_CXX_STANDARD 17)

--- a/external/build_deps.cmake
+++ b/external/build_deps.cmake
@@ -39,8 +39,8 @@
 cmake_minimum_required(VERSION 3.21)
 
 # -- Pinned versions (must match CMakeLists.txt) -----------------------------
-set(LIBXDF_VERSION    "0.99.10")
-set(LIBBIOSIG_VERSION "3.9.4")
+set(LIBXDF_VERSION    "1.0.0")
+set(LIBBIOSIG_VERSION "3.9.5")
 
 # -- Resolve the destination directory ---------------------------------------
 if(NOT DEFINED DEPS_DIR)

--- a/src/file_handling/xdf_reader.cpp
+++ b/src/file_handling/xdf_reader.cpp
@@ -155,13 +155,24 @@ QString XDFReader::loadFixedHeader(const QString& file_path)
                 {
                     /* If and only if the file contains only one sample rate, we use effective
                     sample rate to more accurately display events. Effective sample rates
-                    can be slightly different across streams, so we calculate the mean here */
+                    can be slightly different across streams, so we calculate the mean here.
+                    Streams with only one sample have a zero-length time span, which makes
+                    their effective sample rate infinite; such values must be excluded or
+                    they poison the mean (and the event positions computed from it). */
 
-                    double init = 0.0;
-                    XDFdata->fileEffectiveSampleRate =
-                            std::accumulate(XDFdata->effectiveSampleRateVector.begin(),
-                                            XDFdata->effectiveSampleRateVector.end(), init)
-                            / XDFdata->effectiveSampleRateVector.size();
+                    double sum = 0.0;
+                    int validCount = 0;
+                    for (double rate : XDFdata->effectiveSampleRateVector)
+                    {
+                        if (std::isfinite(rate))
+                        {
+                            sum += rate;
+                            validCount++;
+                        }
+                    }
+
+                    if (validCount)
+                        XDFdata->fileEffectiveSampleRate = sum / validCount;
                 }
             }
                 break;

--- a/src/gui/signal_browser/adapt_browser_view_widget.cpp
+++ b/src/gui/signal_browser/adapt_browser_view_widget.cpp
@@ -40,8 +40,16 @@ AdaptBrowserViewWidget::AdaptBrowserViewWidget (SignalVisualisationView const* s
         throw (Exception (tr("connect failed: y_axis_checkbox_").toStdString()));
     if (!connect (ui_.labels_checkbox_, SIGNAL(toggled(bool)), SIGNAL(labelsVisibilityChanged(bool))))
         throw (Exception (tr("connect failed: labels_checkbox_").toStdString()));
+    // Qt's setMaximum() clamps and re-emits valueChanged() when the spinbox's
+    // current value exceeds the new maximum (e.g. for a very short recording).
+    // At this point in construction, the containing SignalBrowserView hasn't
+    // registered itself with its SignalBrowserModel yet, so a resulting
+    // on_..._valueChanged -> SignalBrowserModel::update() call would crash on
+    // a null view pointer. Suppress it with the same guard updateValues() uses.
+    updating_values_ = true;
     ui_.channelsPerPageSpinbox->setMaximum (setting->getChannelManager().getNumberChannels());
     ui_.secsPerPageSpinbox->setMaximum (settings_->getChannelManager().getDurationInSec());
+    updating_values_ = false;
     connect (settings_.data(), SIGNAL(channelHeightChanged()), SLOT(updateValues()));
     connect (settings_.data(), SIGNAL(gridFragmentationChanged()), SLOT(updateValues()));
     connect (settings_.data(), SIGNAL(pixelsPerSampleChanged()), SLOT(updateValues()));


### PR DESCRIPTION
This requires the fix in libxdf 1.0.0, so bumping this library as well as (unrelated) libbiosig 3.9.5. Also fix a bug when creating the view after loading a file with only a single data point.