### PR TITLE
Fix emtpy string samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 🔧 Fixed
 - Fix multi-channel string/marker stream parsing ([#164](https://github.com/cbrnr/sigviewer/pull/164) by [Clemens Brunner](https://github.com/cbrnr))
 - Fix crash when loading XDF files containing a stream with only one sample ([#164](https://github.com/cbrnr/sigviewer/pull/164) by [Clemens Brunner](https://github.com/cbrnr))
+- Update libxdf to 1.0.1, which skips empty marker samples in regular-rate string streams instead of turning each one into an event ([#166](https://github.com/cbrnr/sigviewer/pull/166) by [Clemens Brunner](https://github.com/cbrnr))
+
 
 ## [0.7.1] · 2026-04-06
 ### ✨ Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Fix crash when loading XDF files containing a stream with only one sample ([#164](https://github.com/cbrnr/sigviewer/pull/164) by [Clemens Brunner](https://github.com/cbrnr))
 - Update libxdf to 1.0.1, which skips empty marker samples in regular-rate string streams instead of turning each one into an event ([#166](https://github.com/cbrnr/sigviewer/pull/166) by [Clemens Brunner](https://github.com/cbrnr))
 
-
 ## [0.7.1] · 2026-04-06
 ### ✨ Added
 - Add DMG background and Applications shortcut for macOS installer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(sigviewer
 # -- Pinned versions of external dependencies --------------------------------
 # These are the ONLY accepted versions. Change them here (and rebuild the
 # pre-built artifacts) when upgrading a dependency.
-set(LIBXDF_VERSION    "1.0.0")
+set(LIBXDF_VERSION    "1.0.1")
 set(LIBBIOSIG_VERSION "3.9.5")
 
 # -- Language standards ------------------------------------------------------

--- a/external/build_deps.cmake
+++ b/external/build_deps.cmake
@@ -39,7 +39,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # -- Pinned versions (must match CMakeLists.txt) -----------------------------
-set(LIBXDF_VERSION    "1.0.0")
+set(LIBXDF_VERSION    "1.0.1")
 set(LIBBIOSIG_VERSION "3.9.5")
 
 # -- Resolve the destination directory ---------------------------------------


### PR DESCRIPTION
Bumping to libxdf 1.0.1, which ignores empty samples in regular string streams.